### PR TITLE
[MC-767] Fix amount and enum decoding errors

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Tabby.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Tabby.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "TabbyTests"
+               BuildableName = "TabbyTests"
+               BlueprintName = "TabbyTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Package.swift
+++ b/Package.swift
@@ -30,5 +30,9 @@ let package = Package(
                 .process("Resources")
             ]
         ),
+        .testTarget(
+            name: "TabbyTests",
+            dependencies: ["Tabby"]
+        )
     ]
 )

--- a/Sources/Tabby/SwiftUI/Helpers/Amount.swift
+++ b/Sources/Tabby/SwiftUI/Helpers/Amount.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Represents a decimal amount. Can be decoded from a string.
+public struct Amount: Codable, Equatable {
+
+    public var value: Decimal {
+        didSet {
+            if oldValue != value {
+                decodedString = nil
+            }
+        }
+    }
+    private var decodedString: String?
+
+    public init(_ value: Decimal) {
+        self.value = value
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        do {
+            let decimal = try container.decode(Decimal.self)
+            self.init(decimal)
+        } catch {
+            if let double = try? container.decode(Double.self) {
+                self.init(Decimal(double))
+                return
+            }
+            guard let string = try? container.decode(String.self) else {
+                throw error
+            }
+            guard let value = Decimal(string: string) else {
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Invalid decimal string: \(string)"
+                    )
+                )
+            }
+            self.init(value)
+            decodedString = string
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+}
+
+extension Amount: Comparable {
+
+    public static func < (lhs: Amount, rhs: Amount) -> Bool {
+        lhs.value < rhs.value
+    }
+}
+
+extension Amount: ExpressibleByFloatLiteral {
+
+    public init(floatLiteral value: Double) {
+        self.init(Decimal(floatLiteral: value))
+    }
+}
+
+extension Amount: ExpressibleByIntegerLiteral {
+
+    public typealias IntegerLiteralType = Decimal.IntegerLiteralType
+
+    public init(integerLiteral value: Int) {
+        self.init(Decimal(integerLiteral: value))
+    }
+}
+
+extension Amount: CustomStringConvertible {
+
+    public var description: String {
+        decodedString ?? value.description
+    }
+}
+
+extension Amount: LosslessStringConvertible {
+
+    public init?(_ description: String) {
+        guard let value = Decimal(string: description) else {
+            return nil
+        }
+        self.init(value)
+        decodedString = description
+    }
+}
+
+extension Amount: Numeric {
+
+    public typealias Magnitude = Amount
+
+    public init?<T>(exactly source: T) where T : BinaryInteger {
+        guard let value = Decimal(exactly: source) else {
+            return nil
+        }
+        self.init(value)
+    }
+
+    public var magnitude: Amount {
+        Amount(value.magnitude)
+    }
+    
+    public static func - (lhs: Amount, rhs: Amount) -> Amount {
+        Amount(lhs.value - rhs.value)
+    }
+
+    public static func * (lhs: Amount, rhs: Amount) -> Amount {
+        Amount(lhs.value * rhs.value)
+    }
+    
+    public static func + (lhs: Amount, rhs: Amount) -> Amount {
+        Amount(lhs.value + rhs.value)
+    }
+
+    public static func *= (lhs: inout Amount, rhs: Amount) {
+        lhs.value *= rhs.value
+    }
+}

--- a/Sources/Tabby/SwiftUI/Helpers/SafeEnum.swift
+++ b/Sources/Tabby/SwiftUI/Helpers/SafeEnum.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// A property wrapper that safely decodes enums.
+@propertyWrapper
+public struct SafeEnum<Value: RawRepresentable & Equatable> {
+
+    public var wrappedValue: Value? {
+        get { rawValue.flatMap { Value(rawValue: $0) } }
+        set { rawValue = newValue?.rawValue }
+    }
+
+    public var projectedValue: Value.RawValue? {
+        get { rawValue }
+        set { rawValue = newValue }
+    }
+
+    public var rawValue: Value.RawValue?
+
+    public init(wrappedValue: Value? = nil) {
+        self.rawValue = wrappedValue?.rawValue
+    }
+
+    public init(rawValue: Value.RawValue) {
+        self.rawValue = rawValue
+    }
+}
+
+extension SafeEnum: Equatable where Value.RawValue: Equatable {
+}
+
+extension SafeEnum: Hashable where Value.RawValue: Hashable, Value: Hashable {
+}
+
+extension SafeEnum: Decodable where Value.RawValue: Decodable {
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(Value.RawValue.self)
+        self.init(rawValue: rawValue)
+    }
+}
+
+extension SafeEnum: Encodable where Value.RawValue: Encodable {
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+extension KeyedDecodingContainer {
+    
+    public func decode<Value: RawRepresentable & Equatable>(
+        _ type: SafeEnum<Value>.Type,
+        forKey key: Key
+    ) throws -> SafeEnum<Value> where Value.RawValue: Decodable {
+        try decodeIfPresent(type, forKey: key) ?? SafeEnum()
+    }
+}
+
+extension KeyedEncodingContainer {
+    
+    public mutating func encode<Value: RawRepresentable & Equatable>(
+        _ value: SafeEnum<Value>,
+        forKey key: Key
+    ) throws where Value.RawValue: Encodable {
+        try encodeIfPresent(value.rawValue.map { _ in value }, forKey: key)
+    }
+}

--- a/Tests/TabbyTests/PaymentDecodingTests.swift
+++ b/Tests/TabbyTests/PaymentDecodingTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import XCTest
+@testable import Tabby
+
+final class PaymentDecodingTests: XCTestCase {
+
+    func testPaymentDecoding() throws {
+        let jsonData = jsonString.data(using: .utf8)!
+        let payment = try JSONDecoder().decode(TabbyCheckoutPayload.self, from: jsonData)
+        dump(payment)
+    }
+
+    private let jsonString: String = """
+{
+    "payment":{
+        "buyer_history":{
+            "is_phone_number_verified":true,
+            "loyalty_level":1,
+            "is_social_networks_connected":true,
+            "is_email_verified":true,
+            "registered_since":"2018-05-18T10:04:00+00:00",
+            "wishlist_count":0
+        },
+        "buyer":{
+            "name":"jaydeep modi",
+            "email":"jaydeep.modi@drcsystems.com",
+            "phone":"8523697410"
+        },
+        "order_history":[
+            {
+                "status":"complete",
+                "shipping_address":{
+                    "address":"Al Khail Mall - Al Quoz - Al Quoz 4 - Dubai - United Arab Emirates",
+                    "zip":"",
+                    "city":"Ahemdabad"
+                },
+                "items":[
+                    {
+                        "category":"",
+                        "quantity":1,
+                        "reference_id":"",
+                        "discount_amount":0.0,
+                        "ordered":1,
+                        "title":"Embroidered Long Frock ",
+                        "shipped":1,
+                        "unit_price":290.0,
+                        "refunded":0,
+                        "captured":1
+                    }
+                ],
+                "buyer":{
+                    "name":"jaydeep modi",
+                    "email":"jaydeep.modi@drcsystems.com",
+                    "phone":"8523697410"
+                },
+                "payment_method":"checkmo",
+                "purchased_at":"2024-07-19T11:09:12+00:00",
+                "amount":320.0
+            },
+            {
+                "status":"canceled",
+                "amount":66.67,
+                "payment_method":"ccavenue",
+                "shipping_address":{
+                    "city":"Dubai",
+                    "zip":"",
+                    "address":"Silver tower ,office no.260"
+                },
+                "items":[
+                    {
+                        "ordered":1,
+                        "title":"Asymmetrical Long dress",
+                        "captured":0,
+                        "unit_price":420.0,
+                        "quantity":1,
+                        "refunded":0,
+                        "shipped":0,
+                        "reference_id":"",
+                        "category":"",
+                        "discount_amount":0.0
+                    },
+                    {
+                        "ordered":1,
+                        "reference_id":"",
+                        "title":"Tulle Long Dress ",
+                        "quantity":1,
+                        "unit_price":350.0,
+                        "captured":0,
+                        "category":"",
+                        "refunded":0,
+                        "shipped":0,
+                        "discount_amount":0.0
+                    }
+                ],
+                "buyer":{
+                    "email":"jaydeep.modi@drcsystems.com",
+                    "phone":"8985856985",
+                    "name":"jaydeep modi"
+                },
+                "purchased_at":"2024-01-11T10:19:12+00:00"
+            },
+            {
+                "status":"canceled",
+                "shipping_address":{
+                    "address":"sds dis dis c.",
+                    "city":"as wad",
+                    "zip":""
+                },
+                "purchased_at":"2023-12-11T11:26:04+00:00",
+                "items":[
+                    {
+                        "category":"",
+                        "shipped":0,
+                        "ordered":1,
+                        "refunded":0,
+                        "unit_price":240.0,
+                        "quantity":1,
+                        "reference_id":"",
+                        "discount_amount":0.0,
+                        "captured":0,
+                        "title":"Wrap over Tulle Dress "
+                    }
+                ],
+                "amount":270.0,
+                "buyer":{
+                    "name":"jaydeep modi",
+                    "email":"jaydeep.modi@drcsystems.com",
+                    "phone":"8000190600"
+                },
+                "payment_method":"checkmo"
+            }
+        ],
+        "order":{
+            "discount_amount":0.0,
+            "tax_amount":0.0,
+            "shipping_amount":30.0,
+            "reference_id":"000002524",
+            "items":[
+                {
+                    "discount_amount":0.0,
+                    "unit_price":0.0,
+                    "quantity":1,
+                    "category":"Women Sale",
+                    "title":"Embellished Long Dress",
+                    "reference_id":"H23630PST.GRNL"
+                }
+            ]
+        },
+        "amount":880.0,
+        "shipping_address":{
+            "city":"Ahemdabad",
+            "zip":"384265",
+            "address":"Al Khail Mall - Al Quoz - Al Quoz 4 - Dubai - United Arab Emirates"
+        },
+        "currency":"AED"
+    },
+    "merchant_code":"uaeapp",
+    "lang":"en"
+}
+"""
+}


### PR DESCRIPTION
 - Add `Amount` type that can be decoded both from a string and number
 - Add `SafeEnum` property wrapper for safe decoding of optional enum variables