### PR TITLE
Core/mpc 2663 geo routing

### DIFF
--- a/Sources/Tabby/SwiftUI/Analytics/AnalyticsService.swift
+++ b/Sources/Tabby/SwiftUI/Analytics/AnalyticsService.swift
@@ -52,7 +52,7 @@ final public class AnalyticsService {
             headers: [
                 "Content-Type": "application/json",
                 "Accept": "application/json",
-                "X-SDK-Version": "iOS/\(version)",
+                SdkVersionHeader.key: SdkVersionHeader.value,
                 "Authorization": "Basic \(getAnalyticsHeader())"
             ], 
             body: preparePayload(event: event)) { (result: Result<Data?, Error>) in

--- a/Sources/Tabby/SwiftUI/Checkout/TabbyCheckout.swift
+++ b/Sources/Tabby/SwiftUI/Checkout/TabbyCheckout.swift
@@ -34,33 +34,41 @@ public final class TabbySDK {
     }
     
     public func configure(forPayment payload: TabbyCheckoutPayload, completion: @escaping (SessionCompletion) -> ()) {
-        Api.shared.createSession(payload: payload, apiKey: TabbySDK.shared.apiKey, completed: { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let s):
-                    self.session = s
-                    var tabbyProductTypes: [TabbyProductType] = []
-                    
-                    for key in TabbyProductType.allCases {
-                        if s.configuration.availableProducts[key.rawValue] != nil {
-                            tabbyProductTypes.append(key)
-                        }
-                    }
+        Task {
+            let config = await SdkConfigService.shared.config()
+            let endpoints = config.endpoints(for: payload.payment.currency)
+            Api.shared.createSession(
+                payload: payload,
+                apiKey: TabbySDK.shared.apiKey,
+                baseUrl: endpoints.checkoutApiBaseUrl
+            ) { result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success(let s):
+                        self.session = s
+                        var tabbyProductTypes: [TabbyProductType] = []
 
-                    let res = SessionCompletionPayload(
-                        sessionId: s.id,
-                        paymentId: s.payment.id,
-                        tabbyProductTypes: tabbyProductTypes,
-                        rejectionReason: s.status == "rejected" ? s.configuration.products.installments.rejection_reason : nil
-                    )
-                    completion(.success(res))
-                    
-                case .failure(let error):
-                    print(error.localizedDescription)
-                    completion(.failure(error))
+                        for key in TabbyProductType.allCases {
+                            if s.configuration.availableProducts[key.rawValue] != nil {
+                                tabbyProductTypes.append(key)
+                            }
+                        }
+
+                        let res = SessionCompletionPayload(
+                            sessionId: s.id,
+                            paymentId: s.payment.id,
+                            tabbyProductTypes: tabbyProductTypes,
+                            rejectionReason: s.status == "rejected" ? s.configuration.products.installments.rejection_reason : nil
+                        )
+                        completion(.success(res))
+
+                    case .failure(let error):
+                        print(error.localizedDescription)
+                        completion(.failure(error))
+                    }
                 }
             }
-        })
+        }
     }
 }
 

--- a/Sources/Tabby/SwiftUI/Checkout/TabbyCheckout.swift
+++ b/Sources/Tabby/SwiftUI/Checkout/TabbyCheckout.swift
@@ -18,12 +18,13 @@ public final class TabbySDK {
     public typealias SessionCompletion = Result<SessionCompletionPayload, CheckoutError>
     
     public static var shared = TabbySDK()
-    
+
     private let analyticsService = AnalyticsService.shared
-    
+    let sdkConfigService = SdkConfigService()
+
     private(set) var apiKey: String = ""
     fileprivate var session: CheckoutSession?
-    
+
     public func setup(withApiKey apiKey: String) {
         self.apiKey = apiKey
 
@@ -45,14 +46,13 @@ public final class TabbySDK {
     /// `SdkConfigService`.
     public func start() {
         Task {
-            _ = await SdkConfigService.shared.config()
+            _ = await sdkConfigService.config()
         }
     }
 
     public func configure(forPayment payload: TabbyCheckoutPayload, completion: @escaping (SessionCompletion) -> ()) {
         Task {
-            let config = await SdkConfigService.shared.config()
-            let endpoints = config.endpoints(for: payload.payment.currency)
+            let endpoints = await sdkConfigService.endpoints(for: payload.payment.currency)
             Api.shared.createSession(
                 payload: payload,
                 apiKey: TabbySDK.shared.apiKey,

--- a/Sources/Tabby/SwiftUI/Checkout/TabbyCheckout.swift
+++ b/Sources/Tabby/SwiftUI/Checkout/TabbyCheckout.swift
@@ -26,13 +26,29 @@ public final class TabbySDK {
     
     public func setup(withApiKey apiKey: String) {
         self.apiKey = apiKey
-                
+
         self.analyticsService.baseURL = BaseURL.analyticsURL
         self.analyticsService.setContextItem(
             .tabbySDK(apiKey: apiKey)
         )
     }
-    
+
+    /// Warms up the SDK by prefetching geo-routing config in the background.
+    ///
+    /// Call from `application(_:didFinishLaunchingWithOptions:)` after `setup(withApiKey:)`
+    /// so the regional endpoints are in cache by the time the first snippet renders or
+    /// `configure(forPayment:)` is called — avoiding a cold-start delay on the first
+    /// merchant-facing request.
+    ///
+    /// Optional: if you skip this, the config is fetched lazily on first use instead.
+    /// Safe to call multiple times — the in-flight request is deduplicated by
+    /// `SdkConfigService`.
+    public func start() {
+        Task {
+            _ = await SdkConfigService.shared.config()
+        }
+    }
+
     public func configure(forPayment payload: TabbyCheckoutPayload, completion: @escaping (SessionCompletion) -> ()) {
         Task {
             let config = await SdkConfigService.shared.config()

--- a/Sources/Tabby/SwiftUI/Checkout/TabbyCheckout.swift
+++ b/Sources/Tabby/SwiftUI/Checkout/TabbyCheckout.swift
@@ -32,19 +32,10 @@ public final class TabbySDK {
         self.analyticsService.setContextItem(
             .tabbySDK(apiKey: apiKey)
         )
-    }
 
-    /// Warms up the SDK by prefetching geo-routing config in the background.
-    ///
-    /// Call from `application(_:didFinishLaunchingWithOptions:)` after `setup(withApiKey:)`
-    /// so the regional endpoints are in cache by the time the first snippet renders or
-    /// `configure(forPayment:)` is called — avoiding a cold-start delay on the first
-    /// merchant-facing request.
-    ///
-    /// Optional: if you skip this, the config is fetched lazily on first use instead.
-    /// Safe to call multiple times — the in-flight request is deduplicated by
-    /// `SdkConfigService`.
-    public func start() {
+        // Kick off /sdk/config in the background so regional endpoints are warm by the time
+        // the first snippet renders or `configure(forPayment:)` runs. Lazy resolution still
+        // works for callers that hit the SDK before this finishes.
         Task {
             _ = await sdkConfigService.config()
         }

--- a/Sources/Tabby/SwiftUI/Config/SdkConfig.swift
+++ b/Sources/Tabby/SwiftUI/Config/SdkConfig.swift
@@ -28,7 +28,8 @@ struct SdkConfig: Equatable {
     let perCurrency: [Currency: Region]
 
     /// Returns endpoints for the given currency, falling back to the `general` block, then to
-    /// the hardcoded default — so callers always get a usable URL.
+    /// the hardcoded production fallback — so callers always get a usable URL even from a
+    /// broken response.
     func endpoints(for currency: Currency) -> Endpoints {
         if let match = perCurrency[currency]?.endpoints {
             return match
@@ -36,23 +37,39 @@ struct SdkConfig: Equatable {
         if let fallback = general?.endpoints {
             return fallback
         }
-        return Self.default.general!.endpoints
+        return .fallback(for: .production)
     }
 
     /// Hardcoded fallback used before `/sdk/config` returns or when the request fails.
-    /// Mirrors the hosts currently referenced from `BaseURL` so behavior matches today's SDK
-    /// when geo-routing is unavailable.
-    static let `default` = SdkConfig(
-        general: Region(
-            endpoints: Endpoints(
+    /// Picks production or staging hosts based on the merchant-selected environment so the
+    /// fallback path stays inside the right environment too.
+    static func `default`(for environment: TabbyEnvironment) -> SdkConfig {
+        SdkConfig(
+            general: Region(endpoints: .fallback(for: environment)),
+            perCurrency: [:]
+        )
+    }
+}
+
+extension SdkConfig.Endpoints {
+    static func fallback(for environment: TabbyEnvironment) -> SdkConfig.Endpoints {
+        switch environment {
+        case .production:
+            return SdkConfig.Endpoints(
                 checkoutApiBaseUrl: "https://api.tabby.ai",
                 webCheckoutBaseUrl: "https://checkout.tabby.ai",
                 widgetsBaseUrl: "https://widgets.tabby.ai",
                 analyticsBaseUrl: "https://dp-event-collector.tabby.ai"
             )
-        ),
-        perCurrency: [:]
-    )
+        case .staging:
+            return SdkConfig.Endpoints(
+                checkoutApiBaseUrl: "https://api.tabby.dev",
+                webCheckoutBaseUrl: "https://checkout.tabby.dev",
+                widgetsBaseUrl: "https://widgets.tabby.dev",
+                analyticsBaseUrl: "https://dp-event-collector.tabby.dev"
+            )
+        }
+    }
 }
 
 extension SdkConfig: Decodable {

--- a/Sources/Tabby/SwiftUI/Config/SdkConfig.swift
+++ b/Sources/Tabby/SwiftUI/Config/SdkConfig.swift
@@ -12,7 +12,7 @@ struct SdkConfig: Equatable {
     struct Endpoints: Decodable, Equatable {
         let checkoutApiBaseUrl: String
         let webCheckoutBaseUrl: String
-        let snippetBaseUrl: String
+        let widgetsBaseUrl: String
         let analyticsBaseUrl: String
     }
 
@@ -47,7 +47,7 @@ struct SdkConfig: Equatable {
             endpoints: Endpoints(
                 checkoutApiBaseUrl: "https://api.tabby.ai",
                 webCheckoutBaseUrl: "https://checkout.tabby.ai",
-                snippetBaseUrl: "https://widgets.tabby.ai",
+                widgetsBaseUrl: "https://widgets.tabby.ai",
                 analyticsBaseUrl: "https://dp-event-collector.tabby.ai"
             )
         ),

--- a/Sources/Tabby/SwiftUI/Config/SdkConfig.swift
+++ b/Sources/Tabby/SwiftUI/Config/SdkConfig.swift
@@ -1,0 +1,77 @@
+// @ai-generated(guided)
+
+import Foundation
+
+/// Region-specific base URLs returned by `POST /api/v1/sdk/config`.
+///
+/// The backend returns a JSON object whose top-level keys are currency codes (ISO 4217) plus
+/// a `general` fallback block. The SDK picks the block matching the merchant's currency and
+/// falls back to `general` when no match exists.
+struct SdkConfig: Equatable {
+
+    struct Endpoints: Decodable, Equatable {
+        let checkoutApiBaseUrl: String
+        let webCheckoutBaseUrl: String
+        let snippetBaseUrl: String
+        let analyticsBaseUrl: String
+    }
+
+    /// The backend nests endpoints under `endpoints` to leave room for future per-region
+    /// fields (feature flags, region metadata, etc.).
+    struct Region: Decodable, Equatable {
+        let endpoints: Endpoints
+    }
+
+    static let generalKey = "general"
+
+    let general: Region?
+    let perCurrency: [Currency: Region]
+
+    /// Returns endpoints for the given currency, falling back to the `general` block, then to
+    /// the hardcoded default — so callers always get a usable URL.
+    func endpoints(for currency: Currency) -> Endpoints {
+        if let match = perCurrency[currency]?.endpoints {
+            return match
+        }
+        if let fallback = general?.endpoints {
+            return fallback
+        }
+        return Self.default.general!.endpoints
+    }
+
+    /// Hardcoded fallback used before `/sdk/config` returns or when the request fails.
+    /// Mirrors the hosts currently referenced from `BaseURL` so behavior matches today's SDK
+    /// when geo-routing is unavailable.
+    static let `default` = SdkConfig(
+        general: Region(
+            endpoints: Endpoints(
+                checkoutApiBaseUrl: "https://api.tabby.ai",
+                webCheckoutBaseUrl: "https://checkout.tabby.ai",
+                snippetBaseUrl: "https://widgets.tabby.ai",
+                analyticsBaseUrl: "https://dp-event-collector.tabby.ai"
+            )
+        ),
+        perCurrency: [:]
+    )
+}
+
+extension SdkConfig: Decodable {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode([String: Region].self)
+
+        var general: Region?
+        var perCurrency: [Currency: Region] = [:]
+        for (key, region) in raw {
+            if key == Self.generalKey {
+                general = region
+            } else if let currency = Currency(rawValue: key) {
+                perCurrency[currency] = region
+            }
+            // Unknown keys are intentionally ignored so the backend can ship new currencies
+            // without breaking older SDK builds.
+        }
+        self.general = general
+        self.perCurrency = perCurrency
+    }
+}

--- a/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
+++ b/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
@@ -58,6 +58,11 @@ final actor SdkConfigService {
         return await task.value
     }
 
+    /// Convenience: returns region-resolved endpoints for the given currency.
+    func endpoints(for currency: Currency) async -> SdkConfig.Endpoints {
+        await config().endpoints(for: currency)
+    }
+
     private func fetch(for environment: TabbyEnvironment) async -> SdkConfig {
         var request = URLRequest(url: environment.sdkConfigURL)
         request.httpMethod = "POST"

--- a/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
+++ b/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
@@ -55,7 +55,7 @@ final actor SdkConfigService {
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("iOS/\(version)", forHTTPHeaderField: "X-Sdk-Version")
+        request.setValue(SdkVersionHeader.value, forHTTPHeaderField: SdkVersionHeader.key)
 
         do {
             let (data, response) = try await perform(request)

--- a/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
+++ b/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
@@ -1,0 +1,88 @@
+// @ai-generated(guided)
+
+import Foundation
+
+/// Lazily fetches `/api/v1/sdk/config` and caches the in-flight `Task` so concurrent callers
+/// share a single network request.
+///
+/// On the first call the actor starts the fetch and stores the `Task`. Any subsequent caller
+/// awaits the same `Task` — so we never hit the endpoint twice and there is no race between
+/// callers seeing different `SdkConfig` values.
+///
+/// The actor never throws: on any failure (network, decode, non-200) it resolves with
+/// `SdkConfig.default`. The failed task stays cached for the lifetime of the SDK session, so
+/// once we have fallen back to defaults we keep using them.
+///
+/// TODO(retry): retry/backoff is intentionally not implemented yet. To decide before adding:
+///   - per-attempt timeout (doc says "~1s ?", marked TBD in the Phase 2 spec)
+///   - retry count and backoff strategy (fixed? exponential? jittered?)
+///   - which failures should be retried (transport errors? 5xx? never 4xx?)
+///   - whether a retry should clear the cached task so a *new* caller triggers re-fetch,
+///     or whether retries should be bounded inside the first call only (current design
+///     caches the failed Task, so today's behavior is "no retry ever")
+@available(iOS 13.0, *)
+final actor SdkConfigService {
+
+    static let shared = SdkConfigService()
+
+    private let endpoint: URL
+    private let session: URLSession
+    private let decoder: JSONDecoder
+
+    private var fetchTask: Task<SdkConfig, Never>?
+
+    init(
+        endpoint: URL = URL(string: "https://api.tabby.ai/api/v1/sdk/config")!,
+        session: URLSession = .shared,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.endpoint = endpoint
+        self.session = session
+        self.decoder = decoder
+    }
+
+    /// Returns the SDK configuration, triggering the fetch on first call and re-using the
+    /// in-flight `Task` for any concurrent callers.
+    func config() async -> SdkConfig {
+        if let existing = fetchTask {
+            return await existing.value
+        }
+        let task = Task { await self.fetch() }
+        fetchTask = task
+        return await task.value
+    }
+
+    private func fetch() async -> SdkConfig {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("iOS/\(version)", forHTTPHeaderField: "X-Sdk-Version")
+
+        do {
+            let (data, response) = try await perform(request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return .default
+            }
+            return try decoder.decode(SdkConfig.self, from: data)
+        } catch {
+            return .default
+        }
+    }
+
+    /// `URLSession.data(for:)` is iOS 15+. Wrap the callback API to back-deploy to iOS 13.
+    private func perform(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        try await withCheckedThrowingContinuation { continuation in
+            session.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let data = data, let response = response else {
+                    continuation.resume(throwing: NetworkError.noResponse)
+                    return
+                }
+                continuation.resume(returning: (data, response))
+            }.resume()
+        }
+    }
+}

--- a/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
+++ b/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
@@ -10,8 +10,14 @@ import Foundation
 /// callers seeing different `SdkConfig` values.
 ///
 /// The actor never throws: on any failure (network, decode, non-200) it resolves with
-/// `SdkConfig.default`. The failed task stays cached for the lifetime of the SDK session, so
-/// once we have fallen back to defaults we keep using them.
+/// `SdkConfig.default(for:)` for the merchant-selected environment. The failed task stays
+/// cached for the lifetime of the SDK session, so once we have fallen back to defaults we
+/// keep using them.
+///
+/// The environment is read once at fetch time (not at actor init) so callers can flip
+/// `EnvironmentManager.setEnvironment(.staging)` before the first checkout call and have the
+/// staging config endpoint picked up. Switching env after the fetch task is cached is a no-op
+/// — we don't re-fetch.
 ///
 /// TODO(retry): retry/backoff is intentionally not implemented yet. To decide before adding:
 ///   - per-attempt timeout (doc says "~1s ?", marked TBD in the Phase 2 spec)
@@ -24,20 +30,20 @@ final actor SdkConfigService {
 
     static let shared = SdkConfigService()
 
-    private let endpoint: URL
     private let session: URLSession
     private let decoder: JSONDecoder
+    private let environment: () -> TabbyEnvironment
 
     private var fetchTask: Task<SdkConfig, Never>?
 
     init(
-        endpoint: URL = URL(string: "https://api.tabby.ai/api/v1/sdk/config")!,
         session: URLSession = .shared,
-        decoder: JSONDecoder = JSONDecoder()
+        decoder: JSONDecoder = JSONDecoder(),
+        environment: @escaping () -> TabbyEnvironment = { EnvironmentManager.shared.getEnvironment() }
     ) {
-        self.endpoint = endpoint
         self.session = session
         self.decoder = decoder
+        self.environment = environment
     }
 
     /// Returns the SDK configuration, triggering the fetch on first call and re-using the
@@ -46,13 +52,14 @@ final actor SdkConfigService {
         if let existing = fetchTask {
             return await existing.value
         }
-        let task = Task { await self.fetch() }
+        let environment = self.environment()
+        let task = Task { await self.fetch(for: environment) }
         fetchTask = task
         return await task.value
     }
 
-    private func fetch() async -> SdkConfig {
-        var request = URLRequest(url: endpoint)
+    private func fetch(for environment: TabbyEnvironment) async -> SdkConfig {
+        var request = URLRequest(url: environment.sdkConfigURL)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(SdkVersionHeader.value, forHTTPHeaderField: SdkVersionHeader.key)
@@ -60,11 +67,11 @@ final actor SdkConfigService {
         do {
             let (data, response) = try await perform(request)
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-                return .default
+                return .default(for: environment)
             }
             return try decoder.decode(SdkConfig.self, from: data)
         } catch {
-            return .default
+            return .default(for: environment)
         }
     }
 

--- a/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
+++ b/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
@@ -28,8 +28,6 @@ import Foundation
 ///     caches the failed Task, so today's behavior is "no retry ever")
 final actor SdkConfigService {
 
-    static let shared = SdkConfigService()
-
     private let session: URLSession
     private let decoder: JSONDecoder
     private let environment: () -> TabbyEnvironment

--- a/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
+++ b/Sources/Tabby/SwiftUI/Config/SdkConfigService.swift
@@ -20,7 +20,6 @@ import Foundation
 ///   - whether a retry should clear the cached task so a *new* caller triggers re-fetch,
 ///     or whether retries should be bounded inside the first call only (current design
 ///     caches the failed Task, so today's behavior is "no retry ever")
-@available(iOS 13.0, *)
 final actor SdkConfigService {
 
     static let shared = SdkConfigService()

--- a/Sources/Tabby/SwiftUI/Constants/Currency.swift
+++ b/Sources/Tabby/SwiftUI/Constants/Currency.swift
@@ -46,3 +46,17 @@ public enum Currency: String, Codable {
     }
 }
 
+/// Lets `Currency` be used directly as a `Dictionary` key in `Codable` payloads — keyed JSON
+/// objects (e.g. `{"SAR": {...}, "AED": {...}}`) decode straight into `[Currency: Value]`
+/// on iOS 15.4+ without a custom container.
+@available(iOS 15.4, macOS 12.3, *)
+extension Currency: CodingKeyRepresentable {
+    public var codingKey: any CodingKey {
+        rawValue.codingKey
+    }
+
+    public init?<T: CodingKey>(codingKey: T) {
+        self.init(rawValue: codingKey.stringValue)
+    }
+}
+

--- a/Sources/Tabby/SwiftUI/Constants/EnvironmentManager.swift
+++ b/Sources/Tabby/SwiftUI/Constants/EnvironmentManager.swift
@@ -1,6 +1,21 @@
+import Foundation
+
 public enum TabbyEnvironment {
     case production
     case staging
+}
+
+extension TabbyEnvironment {
+    /// URL of the SDK config endpoint per environment. Used by `SdkConfigService` to bootstrap
+    /// region-specific URLs; everything downstream comes from the response.
+    var sdkConfigURL: URL {
+        switch self {
+        case .production:
+            return URL(string: "https://api.tabby.ai/api/v1/sdk/config")!
+        case .staging:
+            return URL(string: "https://api.tabby.dev/api/v1/sdk/config")!
+        }
+    }
 }
 
 public final class EnvironmentManager {

--- a/Sources/Tabby/SwiftUI/Constants/Version.swift
+++ b/Sources/Tabby/SwiftUI/Constants/Version.swift
@@ -1,3 +1,11 @@
 import Foundation
 
 let version = "1.7.8"
+
+/// `X-SDK-Version` header sent on every outbound SDK request. Defined once so the format
+/// (`<platform>/<version>`) and casing stay identical across the Checkout API, analytics,
+/// and `/sdk/config` calls.
+enum SdkVersionHeader {
+    static let key = "X-SDK-Version"
+    static let value = "iOS/\(version)"
+}

--- a/Sources/Tabby/SwiftUI/Network/TabbyCheckoutAPI.swift
+++ b/Sources/Tabby/SwiftUI/Network/TabbyCheckoutAPI.swift
@@ -18,10 +18,17 @@ final class Api {
     
     /// Creates a checkout session.
     ///
+    /// - Parameter baseUrl: Region-resolved Checkout API host (e.g. `https://api.tabby.ai`).
+    ///   The `/api/v2/checkout` path is appended here so callers only deal with the host.
     /// - Note: It is highly recommended to send a non-empty order history if a customer had some orders.
-    func createSession(payload: TabbyCheckoutPayload, apiKey: String, completed: @escaping (Result<CheckoutSession, CheckoutError>) -> Void) {
+    func createSession(
+        payload: TabbyCheckoutPayload,
+        apiKey: String,
+        baseUrl: String,
+        completed: @escaping (Result<CheckoutSession, CheckoutError>) -> Void
+    ) {
         networkService.performRequest(
-            url: BaseURL.checkout,
+            url: "\(baseUrl)/api/v2/checkout",
             method: "POST",
             headers: [
                 "Content-Type": "application/json",

--- a/Sources/Tabby/SwiftUI/Network/TabbyCheckoutAPI.swift
+++ b/Sources/Tabby/SwiftUI/Network/TabbyCheckoutAPI.swift
@@ -33,7 +33,7 @@ final class Api {
             headers: [
                 "Content-Type": "application/json",
                 "Accept": "application/json",
-                "X-SDK-Version": "iOS/\(version)",
+                SdkVersionHeader.key: SdkVersionHeader.value,
                 "Authorization": "Bearer \(apiKey)"
             ],
             body: payload

--- a/Sources/Tabby/SwiftUI/SafariView.swift
+++ b/Sources/Tabby/SwiftUI/SafariView.swift
@@ -10,24 +10,17 @@ import SafariServices
 
 @available(iOS 14.0, *)
 struct SafariView: UIViewControllerRepresentable {
-    let lang: Lang
-    let link: String
-    let url: URL?
-    let customUrl: String?
-    
-    init(lang: Lang, customUrl: String? = nil) {
-        self.lang = lang
-        self.link = lang == Lang.en ? BaseURL.WebView.Tabby.en : BaseURL.WebView.Tabby.ar
-        let finalUrl = customUrl ?? (lang == Lang.en ? BaseURL.WebView.Tabby.en : BaseURL.WebView.Tabby.ar)
-        self.url = URL(string: finalUrl)
-        self.customUrl = customUrl
-    }
-    
-    func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
-        let vc = SFSafariViewController(url: url!)
-        return vc
-    }
-    
-    func updateUIViewController(_ uiViewController: SFSafariViewController, context:  UIViewControllerRepresentableContext<SafariView>) {}
-}
+    let url: URL
 
+    /// Callers build the full URL from the geo-resolved `webCheckoutBaseUrl`, so a malformed
+    /// string here would be a programmer error in the SDK itself.
+    init(urlString: String) {
+        self.url = URL(string: urlString)!
+    }
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SafariView>) {}
+}

--- a/Sources/Tabby/SwiftUI/TabbyCardView.swift
+++ b/Sources/Tabby/SwiftUI/TabbyCardView.swift
@@ -74,7 +74,7 @@ public struct TabbyCardView: View {
         }
         .onAppear {
             Task { @MainActor in
-                webCheckoutBaseUrl = await SdkConfigService.shared.endpoints(for: currency).webCheckoutBaseUrl
+                webCheckoutBaseUrl = await TabbySDK.shared.sdkConfigService.endpoints(for: currency).webCheckoutBaseUrl
             }
         }
     }

--- a/Sources/Tabby/SwiftUI/TabbyCardView.swift
+++ b/Sources/Tabby/SwiftUI/TabbyCardView.swift
@@ -31,6 +31,8 @@ public struct TabbyCardView: View {
     private let shouldInheritBg: Bool
     private let merchantCode: String
 
+    @State private var webCheckoutBaseUrl: String?
+
     // MARK: Init
 
     /// Creates a checkout snippet for the checkout page.
@@ -57,8 +59,29 @@ public struct TabbyCardView: View {
 
     // MARK: Body
     public var body: some View {
+        Group {
+            if let webCheckoutBaseUrl = webCheckoutBaseUrl {
+                TabbyWebWidgetView(
+                    htmlContent: html(webCheckoutBaseUrl: webCheckoutBaseUrl),
+                    lang: lang,
+                    analyticsPrefix: "Checkout Card"
+                )
+            } else {
+                // Waiting for /sdk/config — webapp handles its own shimmer once we know the
+                // right regional URL, so nothing native to show here.
+                Color.clear
+            }
+        }
+        .onAppear {
+            Task { @MainActor in
+                webCheckoutBaseUrl = await SdkConfigService.shared.endpoints(for: currency).webCheckoutBaseUrl
+            }
+        }
+    }
+
+    private func html(webCheckoutBaseUrl: String) -> String {
         let dir = lang == .ar ? "rtl" : "ltr"
-        let html = """
+        return """
         <!DOCTYPE html>
         <html lang="\(lang.rawValue)" dir="\(dir)">
         <head>
@@ -68,7 +91,7 @@ public struct TabbyCardView: View {
         </head>
         <body>
             <div id="tabbyCard"></div>
-            <script src="https://checkout.tabby.ai/tabby-card.js"></script>
+            <script src="\(webCheckoutBaseUrl)/tabby-card.js"></script>
             <script>
                 new TabbyCard({
                     selector: '#tabbyCard',
@@ -83,12 +106,6 @@ public struct TabbyCardView: View {
         </body>
         </html>
         """
-
-        return TabbyWebWidgetView(
-            htmlContent: html,
-            lang: lang,
-            analyticsPrefix: "Checkout Card"
-        )
     }
 }
 

--- a/Sources/Tabby/SwiftUI/TabbyProductPageSnippet.swift
+++ b/Sources/Tabby/SwiftUI/TabbyProductPageSnippet.swift
@@ -11,29 +11,31 @@ import SwiftUI
 @available(iOS 14.0, macOS 11, *)
 public struct TabbyProductPageSnippet: View {
     @State private var isOpened: Bool = false
+    @State private var webCheckoutBaseUrl: String?
     @Environment(\.layoutDirection) var direction
-    
+
     private let analyticsService = AnalyticsService.shared
-    
+
     func toggleOpen() -> Void {
         isOpened.toggle()
     }
-    
+
     let amount: Double
     let currency: Currency
     let withCurrencyInArabic: Bool
-    
+
     private let installmentsCount = 4
-    
+
     private var isRTL: Bool {
         direction == .rightToLeft
     }
-    
-    private var pageURL: String {
-        let baseURL = isRTL ? BaseURL.WebView.Tabby.ar : BaseURL.WebView.Tabby.en
-        return "\(baseURL)?price=\(amount)&currency=\(currency.rawValue)&source=sdk"
+
+    private var pageURL: String? {
+        guard let baseUrl = webCheckoutBaseUrl else { return nil }
+        let path = isRTL ? "/promos/product-page/installments/ar/" : "/promos/product-page/installments/en/"
+        return "\(baseUrl)\(path)?price=\(amount)&currency=\(currency.rawValue)&source=sdk"
     }
-    
+
     private var pageLang: Lang {
         isRTL ? .ar : .en
     }
@@ -92,6 +94,7 @@ public struct TabbyProductPageSnippet: View {
             .padding(.horizontal, 16)
             .environment(\.layoutDirection, isRTL ? .rightToLeft : .leftToRight)
             .onTapGesture {
+                guard pageURL != nil else { return }
                 analyticsService.send(event: .LearnMore.clicked(currency: currency, installmentsCount: installmentsCount))
                 toggleOpen()
             }
@@ -99,14 +102,19 @@ public struct TabbyProductPageSnippet: View {
         .sheet(isPresented: $isOpened, onDismiss: {
             analyticsService.send(event: .LearnMore.popUpClosed(currency: currency, installmentsCount: installmentsCount))
         }, content: {
-            SafariView(lang: pageLang, customUrl: pageURL)
-                .onAppear(perform: {
-                    analyticsService.send(event: .LearnMore.popUpOpened(currency: currency, installmentsCount: installmentsCount))
-                })
+            if let pageURL = pageURL {
+                SafariView(urlString: pageURL)
+                    .onAppear(perform: {
+                        analyticsService.send(event: .LearnMore.popUpOpened(currency: currency, installmentsCount: installmentsCount))
+                    })
+            }
         })
-        .onAppear(perform: {
+        .onAppear {
+            Task { @MainActor in
+                webCheckoutBaseUrl = await TabbySDK.shared.sdkConfigService.endpoints(for: currency).webCheckoutBaseUrl
+            }
             analyticsService.send(event: .SnippedCard.rendered(currency: currency, installmentsCount: installmentsCount))
-        })
+        }
     }
 }
 

--- a/Sources/Tabby/SwiftUI/TabbySnippetView.swift
+++ b/Sources/Tabby/SwiftUI/TabbySnippetView.swift
@@ -77,7 +77,7 @@ public struct TabbySnippetView: View {
         }
         .onAppear {
             Task { @MainActor in
-                widgetsBaseUrl = await SdkConfigService.shared.endpoints(for: currency).widgetsBaseUrl
+                widgetsBaseUrl = await TabbySDK.shared.sdkConfigService.endpoints(for: currency).widgetsBaseUrl
             }
         }
     }

--- a/Sources/Tabby/SwiftUI/TabbySnippetView.swift
+++ b/Sources/Tabby/SwiftUI/TabbySnippetView.swift
@@ -26,6 +26,8 @@ public struct TabbySnippetView: View {
     private let lang: Lang
     private let shouldInheritBg: Bool
 
+    @State private var widgetsBaseUrl: String?
+
     // MARK: Init
 
     /// Creates a promotional snippet for product or cart pages.
@@ -47,22 +49,36 @@ public struct TabbySnippetView: View {
         self.shouldInheritBg = shouldInheritBg
     }
 
-    // MARK: Body
-    public var body: some View {
-        let price = Int(amount)
-        let queryParams: [String: String] = [
-            "price": "\(price)",
+    private var queryParams: [String: String] {
+        [
+            "price": "\(Int(amount))",
             "currency": currency.rawValue,
             "lang": lang.rawValue,
             "publicKey": TabbySDK.shared.apiKey,
             "shouldInheritBg": "\(shouldInheritBg)"
         ]
+    }
 
-        return TabbyWebWidgetView(
-            widgetURL: BaseURL.WebView.Widgets.promo,
-            queryParams: queryParams,
-            lang: lang,
-            analyticsPrefix: "Snippet"
-        )
+    // MARK: Body
+    public var body: some View {
+        Group {
+            if let widgetsBaseUrl = widgetsBaseUrl {
+                TabbyWebWidgetView(
+                    widgetURL: "\(widgetsBaseUrl)/tabby-promo.html",
+                    queryParams: queryParams,
+                    lang: lang,
+                    analyticsPrefix: "Snippet"
+                )
+            } else {
+                // Waiting for /sdk/config — webapp handles its own shimmer once we know the
+                // right regional URL, so nothing native to show here.
+                Color.clear
+            }
+        }
+        .onAppear {
+            Task { @MainActor in
+                widgetsBaseUrl = await SdkConfigService.shared.endpoints(for: currency).widgetsBaseUrl
+            }
+        }
     }
 }

--- a/Sources/Tabby/SwiftUI/TabbySplititCheckoutSnippet.swift
+++ b/Sources/Tabby/SwiftUI/TabbySplititCheckoutSnippet.swift
@@ -12,9 +12,10 @@ import SwiftUI
 public struct TabbySplititCheckoutSnippet: View {
     @Environment(\.layoutDirection) var direction
     @State private var isOpened: Bool = false
+    @State private var webCheckoutBaseUrl: String?
 
     private let analyticsService = AnalyticsService.shared
-    
+
     func toggleOpen() -> Void {
         isOpened.toggle()
     }
@@ -26,13 +27,13 @@ public struct TabbySplititCheckoutSnippet: View {
     var urls: (String, String) = ("", "")
 
     private var overwritenURL: String?
-    private var pageURL: String {
-        if let overwritenURL {
+    private var pageURL: String? {
+        if let overwritenURL = overwritenURL {
             return overwritenURL
         }
-        
-        let baseURL = isRTL ? BaseURL.WebView.Splitit.ar : BaseURL.WebView.Splitit.en
-        return "\(baseURL)?price=\(amount)&currency=\(currency.rawValue)&splitPeriod=\(splitPeriod)"
+        guard let baseUrl = webCheckoutBaseUrl else { return nil }
+        let path = isRTL ? "/promos/checkout-page/credit-card-installments/ar/" : "/promos/checkout-page/credit-card-installments/en/"
+        return "\(baseUrl)\(path)?price=\(amount)&currency=\(currency.rawValue)&splitPeriod=\(splitPeriod)"
     }
     
     private var isRTL: Bool {
@@ -137,6 +138,7 @@ public struct TabbySplititCheckoutSnippet: View {
           .background(Color(.white))
           .padding(.horizontal, 16)
           .onTapGesture {
+              guard pageURL != nil else { return }
               analyticsService.send(event: .LearnMore.clicked(currency: currency, installmentsCount: splitPeriod))
               toggleOpen()
           }
@@ -144,14 +146,19 @@ public struct TabbySplititCheckoutSnippet: View {
         .sheet(isPresented: $isOpened, onDismiss: {
             analyticsService.send(event: .LearnMore.popUpClosed(currency: currency, installmentsCount: splitPeriod))
         }, content: {
-          SafariView(lang: pageLang, customUrl: pageURL)
-            .onAppear(perform: {
-                analyticsService.send(event: .LearnMore.popUpOpened(currency: currency, installmentsCount: splitPeriod))
-            })
+          if let pageURL = pageURL {
+              SafariView(urlString: pageURL)
+                .onAppear(perform: {
+                    analyticsService.send(event: .LearnMore.popUpOpened(currency: currency, installmentsCount: splitPeriod))
+                })
+          }
         })
-        .onAppear(perform: {
+        .onAppear {
+            Task { @MainActor in
+                webCheckoutBaseUrl = await TabbySDK.shared.sdkConfigService.endpoints(for: currency).webCheckoutBaseUrl
+            }
             analyticsService.send(event: .SnippedCard.rendered(currency: currency, installmentsCount: splitPeriod))
-        })
+        }
     }
 }
 

--- a/Sources/Tabby/SwiftUI/TabbySplititPresentationalSnippet.swift
+++ b/Sources/Tabby/SwiftUI/TabbySplititPresentationalSnippet.swift
@@ -12,6 +12,7 @@ import SwiftUI
 public struct TabbyCreditCardInstallmentsSnippet: View {
     @Environment(\.layoutDirection) var direction
     @State private var isOpened: Bool = false
+    @State private var webCheckoutBaseUrl: String?
 
     private let analyticsService = AnalyticsService.shared
 
@@ -24,15 +25,15 @@ public struct TabbyCreditCardInstallmentsSnippet: View {
     let withCurrencyInArabic: Bool
     let splitPeriod: Int
     var urls: (String, String) = ("", "")
-    
+
     private var overwritenURL: String?
-    private var pageURL: String {
-        if let overwritenURL {
+    private var pageURL: String? {
+        if let overwritenURL = overwritenURL {
             return overwritenURL
         }
-        
-        let baseURL = isRTL ? BaseURL.WebView.Splitit.ar : BaseURL.WebView.Splitit.en
-        return "\(baseURL)?price=\(amount)&currency=\(currency.rawValue)&splitPeriod=\(splitPeriod)"
+        guard let baseUrl = webCheckoutBaseUrl else { return nil }
+        let path = isRTL ? "/promos/checkout-page/credit-card-installments/ar/" : "/promos/checkout-page/credit-card-installments/en/"
+        return "\(baseUrl)\(path)?price=\(amount)&currency=\(currency.rawValue)&splitPeriod=\(splitPeriod)"
     }
     
     private var isRTL: Bool {
@@ -102,6 +103,7 @@ public struct TabbyCreditCardInstallmentsSnippet: View {
             .padding(.horizontal, 16)
             .environment(\.layoutDirection, isRTL ? .rightToLeft : .leftToRight)
             .onTapGesture {
+                guard pageURL != nil else { return }
                 analyticsService.send(event: .LearnMore.clicked(currency: currency, installmentsCount: splitPeriod))
                 toggleOpen()
             }
@@ -109,15 +111,20 @@ public struct TabbyCreditCardInstallmentsSnippet: View {
           .sheet(isPresented: $isOpened, onDismiss: {
               analyticsService.send(event: .LearnMore.popUpClosed(currency: currency, installmentsCount: splitPeriod))
           }, content: {
-            SafariView(lang: pageLang, customUrl: pageURL)
-              .onAppear(perform: {
-                  analyticsService.send(event: .LearnMore.popUpOpened(currency: currency, installmentsCount: splitPeriod))
-              })
+            if let pageURL = pageURL {
+                SafariView(urlString: pageURL)
+                  .onAppear(perform: {
+                      analyticsService.send(event: .LearnMore.popUpOpened(currency: currency, installmentsCount: splitPeriod))
+                  })
+            }
           })
         }
-        .onAppear(perform: {
+        .onAppear {
+            Task { @MainActor in
+                webCheckoutBaseUrl = await TabbySDK.shared.sdkConfigService.endpoints(for: currency).webCheckoutBaseUrl
+            }
             analyticsService.send(event: .SnippedCard.rendered(currency: currency, installmentsCount: splitPeriod))
-        })
+        }
     }
 }
 


### PR DESCRIPTION
## [iOS][CheckoutSDK] support geo-routing

Phase 2 geo-routing per the [ADR](https://www.notion.so/tabby/GeoSharding-and-Checkout-SDK-2f47977324d280e69ea4d772c51570bb): the SDK fetches its regional endpoints from `POST /api/v1/sdk/config` and resolves per-merchant currency on the fly, so KSA traffic stops hitting MENA hosts.

### What's added
- **`SdkConfigService`** — actor that lazily fetches `/sdk/config` and caches the in-flight `Task`. Concurrent callers share one request; on failure (network/decode/non-200) we fall back to hardcoded defaults for the active environment. Owned by `TabbySDK` (no second global).
- **`setup(withApiKey:)`** now kicks off the fetch in the background, so by the time the first snippet renders or `configure(forPayment:)` runs, the cache is warm. Lazy resolution still works if `setup` is skipped.
- **`TabbyEnvironment.sdkConfigURL`** — `api.tabby.ai` for prod, `api.tabby.dev` for staging. Read at fetch time, so `EnvironmentManager.setEnvironment(.staging)` before the first call switches everything (config endpoint + fallback URLs) coherently.
- **`SdkVersionHeader`** — one place for the `X-SDK-Version: iOS/<version>` header (was duplicated across Checkout API, analytics, and the new config call).

### Routed call sites
| Call site | Field from config |
|---|---|
| `configure(forPayment:)` → create session | `checkoutApiBaseUrl` |
| `TabbySnippetView` (`tabby-promo.html`) | `widgetsBaseUrl` |
| `TabbyCardView` (`tabby-card.js`) | `webCheckoutBaseUrl` |
| `TabbyProductPageSnippet`, `TabbySplititCheckoutSnippet`, `TabbyCreditCardInstallmentsSnippet` (Learn More) | `webCheckoutBaseUrl` |

Snippets render `Color.clear` while the config is loading; the webapp inside the WKWebView handles its own shimmer once the regional URL is set. Deprecated snippets are routed too — compliance requires no SDK path to keep hitting `*.tabby.ai` for KSA, including legacy integrations.

### Notable
- Response field is **`widgetsBaseUrl`**, not `snippetBaseUrl` as the original Notion doc stated — verified against the live endpoint and aligned with the final config approved by Илья / Дмитрий Воловод / Артём Фролков.
- `SafariView` lost its unused `lang`/`link` properties and its dead `BaseURL.WebView.Tabby` fallback.

### Not in scope
- **Analytics URL routing** — part of the separate "Sync and clean up analytics events" task where the iOS analytics layer may be removed entirely.
- **Retry policy** — kept as a `TODO(retry)` block on `SdkConfigService`; current behavior is no retry. Open questions (per-attempt timeout, backoff, which failures to retry, whether to clear the cached failed `Task`) are tracked there.
- **`TabbyCheckoutSnippet`** — native SwiftUI rendering, no hosts to route.
